### PR TITLE
Fix localizations on ApacheHadoop [2/6]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -38,9 +38,11 @@ locale_additions:
     nav:
       apachehadoop: Apache Hadoop
     barclamp:
+      apachehadoop:
         index:
+          title: Apache Hadoop
           barclamp: Project
           state: Status
           proposal: Proposal
-          description: Apache Hadoop Framework includes multiple projects and ecosystem components that support large scale data analytics
-          instructions: Apply proposals in order from top to bottom. Allow each proposal to enter ready state before applying the next one.
+          description: Description
+          instructions: Apache Hadoop Framework includes multiple projects and ecosystem components that support large scale data analytics.  Apply proposals in order from top to bottom. Allow each proposal to enter ready state before applying the next one.

--- a/crowbar_framework/app/controllers/apachehadoop_controller.rb
+++ b/crowbar_framework/app/controllers/apachehadoop_controller.rb
@@ -21,5 +21,12 @@ class ApachehadoopController < BarclampController
   def initialize
     @service_object = ApachehadoopService.new logger
   end
+  
+  def index
+    @title = I18n.t('title', :scope=>'barclamp.apachehadoop.index')
+    super
+  end
+  
 end
 
+  


### PR DESCRIPTION
Mainly this fixes location errors from the last checkin

Added the ability for a metabarclamp to set the name for the 
barclamp list.  This is really helpful because the all the
metabarclamps are multiple word items.  We want to read 
"Apache Hadoop" instead of "Apachehadoop Memembers."  The former
is much more readable.

A similar change needs to be made to the OpenStack barclamp.

 crowbar.yml                                        |    6 ++++--
 .../app/controllers/apachehadoop_controller.rb     |    7 +++++++
 2 files changed, 11 insertions(+), 2 deletions(-)
