### PR TITLE
Move the crowbar.yml layout to v2 [22/27]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -26,6 +26,6 @@ barclamp:
     - apachehadoop
 
 crowbar:
-  layout: 1
+  layout: 2
   order: 200
 

--- a/crowbar_framework/doc/apachehadoop.yml
+++ b/crowbar_framework/doc/apachehadoop.yml
@@ -1,0 +1,12 @@
+# theses are the default meta_data values
+license:    Apache 2
+copyright:  2012 by Dell, Inc
+date:       July 25, 2012
+
+crowbar+book-barclamps:
+  apachehadoop+meta
+    apachehadoop+barclamp-info
+    
+crowbar+book-licenses:
+  apachehadoop+licenses-meta:
+    apachehadoop+licenses

--- a/crowbar_framework/doc/default/apachehadoop/barclamp-info.md
+++ b/crowbar_framework/doc/default/apachehadoop/barclamp-info.md
@@ -1,0 +1,5 @@
+### Apache Hadoop Barclamp
+
+This barclamp does... 
+
+

--- a/crowbar_framework/doc/default/apachehadoop/licenses-meta.md
+++ b/crowbar_framework/doc/default/apachehadoop/licenses-meta.md
@@ -1,0 +1,12 @@
+## Hadoop Suite
+
+This file contains information (if updated by the barclamp authors!) about the licenses that apply to your installation.
+
+There are multiple components included in the Hadoop Suite.
+
+The following dependencies are required:
+
+* ?
+
+
+

--- a/crowbar_framework/doc/default/apachehadoop/licenses.md
+++ b/crowbar_framework/doc/default/apachehadoop/licenses.md
@@ -1,0 +1,10 @@
+### Apache Hadoop Barclamp Licenses
+
+This file contains information (if updated by the barclamp authors!) about the licenses that apply to your installation.
+
+The following dependencies are required:
+
+* ?
+
+
+

--- a/crowbar_framework/doc/default/apachehadoop/meta.md
+++ b/crowbar_framework/doc/default/apachehadoop/meta.md
@@ -1,0 +1,5 @@
+## Hadoop Suite Barclamp
+
+This barclamp does... 
+
+


### PR DESCRIPTION
Recent changes to add the database required us to update
the layout version.

I also added a doc skeleton while I was touching everything

 crowbar.yml                                        |    2 +-
 crowbar_framework/doc/apachehadoop.yml             |   12 ++++++++++++
 .../doc/default/apachehadoop/barclamp-info.md      |    5 +++++
 .../doc/default/apachehadoop/licenses-meta.md      |   12 ++++++++++++
 .../doc/default/apachehadoop/licenses.md           |   10 ++++++++++
 crowbar_framework/doc/default/apachehadoop/meta.md |    5 +++++
 6 files changed, 45 insertions(+), 1 deletions(-)
